### PR TITLE
Enable to import update and wrapCursor functions individually

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,7 +9,7 @@ engines:
     enabled: true
 ratings:
   paths:
-  - index.js.flow
+  - 'src/*.js'
 exclude_paths:
 - karma.conf.js
-- index.spec.js
+- test

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,6 +3,7 @@
 
   env:
     browser: true
+    node: true
 
   extends: eslint:recommended
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,4 @@ typings/
 # dotenv environment variables file
 .env
 
-index.js
+lib

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+npm-debug.log
+src
+test
+undate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- Export update function as "update" not as default
+
 ### Fixed
 - Enable to import update and wrapCursor functions individually
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Enable to import update and wrapCursor functions individually
 
 ## [0.1.2] - 2017-06-28
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ npm install --save undate
 ## Usage
 
 ```js
-import update from 'undate/lib/update';
-import wrapCursor from 'undate/lib/wrapCursor';
+import {update, wrapCursor} from 'undate';
 
 const textareaElement = document.getElementById('textarea');
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ npm install --save undate
 ## Usage
 
 ```js
-import update, {wrapCursor} from 'undate';
+import update from 'undate/lib/update';
+import wrapCursor from 'undate/lib/wrapCursor';
 
 const textareaElement = document.getElementById('textarea');
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'index.spec.js'
+      'test/index.spec.js'
     ],
 
 
@@ -27,7 +27,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'index.spec.js': 'webpack'
+      'test/index.spec.js': 'webpack'
     },
 
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "undate",
   "version": "0.1.2",
   "description": "Undoable update for HTMLTextAreaElement",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
-    "build": "babel -o index.js index.js.flow",
+    "build": "babel src -d lib && for js in src/*.js; do cp $js lib/${js##*/}.flow; done",
     "test": "run-p test:*",
-    "test:eslint": "eslint index.js.flow index.spec.js",
+    "test:eslint": "eslint src/*.js test/*.js",
     "test:flow": "flow",
     "test:karma": "karma start --single-run"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,5 @@
 import update from './update';
 import wrapCursor from './wrapCursor';
 
-module.exports = update;
-(module.exports: any).wrapCursor = wrapCursor;
+module.exports.update = update;
+module.exports.wrapCursor = wrapCursor;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+// @flow
+
+import update from './update';
+import wrapCursor from './wrapCursor';
+
+module.exports = update;
+(module.exports: any).wrapCursor = wrapCursor;

--- a/src/update.js
+++ b/src/update.js
@@ -1,6 +1,6 @@
 // @flow
 
-export default function update(el: HTMLTextAreaElement, headToCursor: string, cursorToTail: ?string) {
+export default function (el: HTMLTextAreaElement, headToCursor: string, cursorToTail: ?string) {
   const curr = el.value,                            // strA + strB1 + strC
         next = headToCursor + (cursorToTail || ''), // strA + strB2 + strC
         activeElement = document.activeElement;
@@ -31,14 +31,3 @@ export default function update(el: HTMLTextAreaElement, headToCursor: string, cu
   el.setSelectionRange(headToCursor.length, headToCursor.length);
   return el;
 }
-
-export function wrapCursor(el: HTMLTextAreaElement, before: string, after: ?string) {
-  const initEnd = el.selectionEnd,
-        headToCursor = el.value.substr(0, el.selectionStart) + before,
-        cursorToTail = el.value.substring(el.selectionStart, initEnd) + (after || '') + el.value.substr(initEnd);
-  update(el, headToCursor, cursorToTail);
-  el.selectionEnd = initEnd + before.length;
-  return el;
-}
-
-// vim:filetype=javascript

--- a/src/wrapCursor.js
+++ b/src/wrapCursor.js
@@ -1,0 +1,12 @@
+// @flow
+
+import update from './update';
+
+export default function (el: HTMLTextAreaElement, before: string, after: ?string) {
+  const initEnd = el.selectionEnd,
+        headToCursor = el.value.substr(0, el.selectionStart) + before,
+        cursorToTail = el.value.substring(el.selectionStart, initEnd) + (after || '') + el.value.substr(initEnd);
+  update(el, headToCursor, cursorToTail);
+  el.selectionEnd = initEnd + before.length;
+  return el;
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import update, {wrapCursor} from './index.js.flow';
+import update, {wrapCursor} from '../src/index.js';
 
 function eq(a, b) {
   if (a !== b) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import update, {wrapCursor} from '../src/index.js';
+import {update, wrapCursor} from '../src/index.js';
 
 function eq(a, b) {
   if (a !== b) {


### PR DESCRIPTION
## Before 

```js
import update, {wrapCursor} from 'undate';
```

## After

```js
import {update, wrapCursor} from 'undate';

// AND

import update from 'undate/lib/update';
import wrapCursor from 'undate/lib/wrapCursor'
```