### PR TITLE
Fix bug that removing part of heading string causes wrong result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to [keepachangelog.com](http://keepachangelog.com).
 ## [Unreleased]
 ### Fixed
 - Fix element focus bug in safari
+- Fix bug that removing part of heading string causes wrong result
 
 ## [0.2.0] - 2017-07-03
 ### Changed

--- a/src/update.js
+++ b/src/update.js
@@ -10,7 +10,7 @@ export default function (el: HTMLTextAreaElement, headToCursor: string, cursorTo
       cLength = 0;
   while (curr[aLength] === next[aLength]) { aLength++; }
   while (curr[curr.length - cLength - 1] === next[next.length - cLength - 1]) { cLength++; }
-  aLength = Math.min(aLength, curr.length - cLength);
+  aLength = Math.min(aLength, Math.min(curr.length, next.length) - cLength);
 
   // Select strB1
   el.setSelectionRange(aLength, curr.length - cLength);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -81,6 +81,19 @@ describe('index', () => {
         eq(document.activeElement, activeElement);
       });
     });
+
+    context('when removing part of heading string', () => {
+      beforeEach(() => {
+        el.value = '            - markdown list';
+      });
+
+      it('works', () => {
+        update(el, '        - markdown list');
+        eq(el.value, '        - markdown list');
+        eq(el.selectionStart, '        - markdown list'.length);
+        eq(el.selectionEnd, '        - markdown list'.length);
+      });
+    });
   });
 
   describe('module.exports.wrapCursor', () => {


### PR DESCRIPTION
It is too difficult for me to explain what was the problem and why this commit fixes it. See the added test case.