### PR TITLE
Fix potential infinite loop

### DIFF
--- a/src/update.js
+++ b/src/update.js
@@ -9,7 +9,7 @@ export default function (el: HTMLTextAreaElement, headToCursor: string, cursorTo
   let aLength = 0,
       cLength = 0;
   while (aLength < curr.length && aLength < next.length && curr[aLength] === next[aLength]) { aLength++; }
-  while (curr[curr.length - cLength - 1] === next[next.length - cLength - 1]) { cLength++; }
+  while (curr.length - cLength - 1 >= 0 && next.length - cLength - 1 >= 0 && curr[curr.length - cLength - 1] === next[next.length - cLength - 1]) { cLength++; }
   aLength = Math.min(aLength, Math.min(curr.length, next.length) - cLength);
 
   // Select strB1

--- a/src/update.js
+++ b/src/update.js
@@ -8,7 +8,7 @@ export default function (el: HTMLTextAreaElement, headToCursor: string, cursorTo
   //  Calculate length of strA and strC
   let aLength = 0,
       cLength = 0;
-  while (curr[aLength] === next[aLength]) { aLength++; }
+  while (aLength < curr.length && aLength < next.length && curr[aLength] === next[aLength]) { aLength++; }
   while (curr[curr.length - cLength - 1] === next[next.length - cLength - 1]) { cLength++; }
   aLength = Math.min(aLength, Math.min(curr.length, next.length) - cLength);
 


### PR DESCRIPTION
I've hit a case where this function can infinite loop - while iterating through `curr` and `next`, if they are equal (say, the first time textcomplete adds a result), they'll loop forever because each character will compare equal, and then it'll do `undefined === undefined` as it goes off the end of the arrays. Checking the index against length fixes this.